### PR TITLE
追加、変更点

### DIFF
--- a/Class/Models/Block.h
+++ b/Class/Models/Block.h
@@ -15,6 +15,8 @@
 #include "../../HumimotoEngine/MaterialData.h"
 #include "../../HumimotoEngine/Manager/TextureManager.h"
 #include "../../HumimotoEngine/base/DirectXCommon.h"
+#include "../../HumimotoEngine/base/WorldTransform.h"
+#include "../../HumimotoEngine/base/ViewProjection.h"
 
 class Block {
 public: // メンバ関数
@@ -40,7 +42,7 @@ public: // メンバ関数
 	/// <param name="scele">大きさ</param>
 	/// <param name="rotate">回転</param>
 	/// <param name="textureNum">textureManagerで作ったenum型の番号</param>
-	void Draw(Vector3 translate, Vector3 scele, Vector3 rotate, int textureNum);	// 描画
+	void Draw(const WorldTransform& worldTransform, const ViewProjection& viewProjection, int textureNum);	// 描画
 
 public:
 	// SRT

--- a/HumimotoEngine/CG2_0_DirectX_take2.vcxproj
+++ b/HumimotoEngine/CG2_0_DirectX_take2.vcxproj
@@ -102,7 +102,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="..\Class\Map\Map.cpp" />
     <ClCompile Include="..\Class\Models\Block.cpp" />
     <ClCompile Include="base\DirectXCommon.cpp" />
+    <ClCompile Include="base\ViewProjection.cpp" />
     <ClCompile Include="base\WinApp.cpp" />
+    <ClCompile Include="base\WorldTransform.cpp" />
     <ClCompile Include="components\Audio.cpp" />
     <ClCompile Include="components\camera\Camera.cpp" />
     <ClCompile Include="components\camera\DebugCamera.cpp" />
@@ -123,6 +125,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="externals\ImGui\imgui_tables.cpp" />
     <ClCompile Include="externals\ImGui\imgui_widgets.cpp" />
     <ClCompile Include="MaterialData.cpp" />
+    <ClCompile Include="object\Cube.cpp" />
     <ClCompile Include="object\Sphere.cpp" />
     <ClCompile Include="object\Sprite.cpp" />
     <ClCompile Include="object\Triangle.cpp" />
@@ -156,7 +159,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="..\Class\Map\Map.h" />
     <ClInclude Include="..\Class\Models\Block.h" />
     <ClInclude Include="base\DirectXCommon.h" />
+    <ClInclude Include="base\ViewProjection.h" />
     <ClInclude Include="base\WinApp.h" />
+    <ClInclude Include="base\WorldTransform.h" />
     <ClInclude Include="components\Audio.h" />
     <ClInclude Include="components\camera\Camera.h" />
     <ClInclude Include="components\camera\DebugCamera.h" />
@@ -184,6 +189,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Material.h" />
     <ClInclude Include="MaterialData.h" />
     <ClInclude Include="ModelData.h" />
+    <ClInclude Include="object\Cube.h" />
     <ClInclude Include="object\Sphere.h" />
     <ClInclude Include="object\Sprite.h" />
     <ClInclude Include="object\Triangle.h" />

--- a/HumimotoEngine/CG2_0_DirectX_take2.vcxproj.filters
+++ b/HumimotoEngine/CG2_0_DirectX_take2.vcxproj.filters
@@ -190,6 +190,15 @@
     <ClCompile Include="..\Class\Map\Map.cpp">
       <Filter>Class\Map</Filter>
     </ClCompile>
+    <ClCompile Include="base\WorldTransform.cpp">
+      <Filter>ソース ファイル\base</Filter>
+    </ClCompile>
+    <ClCompile Include="base\ViewProjection.cpp">
+      <Filter>ソース ファイル\base</Filter>
+    </ClCompile>
+    <ClCompile Include="object\Cube.cpp">
+      <Filter>ソース ファイル\object</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <FxCompile Include="Object3d.VS.hlsl">
@@ -346,6 +355,15 @@
     </ClInclude>
     <ClInclude Include="..\Class\Map\Map.h">
       <Filter>Class\Map</Filter>
+    </ClInclude>
+    <ClInclude Include="base\WorldTransform.h">
+      <Filter>ヘッダー ファイル\base</Filter>
+    </ClInclude>
+    <ClInclude Include="base\ViewProjection.h">
+      <Filter>ヘッダー ファイル\base</Filter>
+    </ClInclude>
+    <ClInclude Include="object\Cube.h">
+      <Filter>ヘッダー ファイル\object</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/HumimotoEngine/Manager/GameManager.cpp
+++ b/HumimotoEngine/Manager/GameManager.cpp
@@ -60,7 +60,7 @@ void GameManager::Initialize() {
 	imGuiManager_->Initialize(winApp_->GetHwnd());
 
 	// ブローバル変数の読み込み
-	GlobalVariables::GetInstance()->LoadFiles();
+	//GlobalVariables::GetInstance()->LoadFiles();
 
 	//初期シーンの設定
 	sceneNum_ = TITLE_SCENE;
@@ -144,7 +144,7 @@ void GameManager::BeginFrame() {
 	// ImGui
 	imGuiManager_->PreDraw();
 	// グローバル変数の更新
-	GlobalVariables::GetInstance()->Update();
+	//GlobalVariables::GetInstance()->Update();
 }
 
 void GameManager::EndFrame() {

--- a/HumimotoEngine/Manager/PipelineManager.cpp
+++ b/HumimotoEngine/Manager/PipelineManager.cpp
@@ -132,6 +132,10 @@ void MyEngine::CreateRootParameter() {
 	rootParameters_[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
 	rootParameters_[1].Descriptor.ShaderRegister = 0;
 
+	rootParameters_[4].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+	rootParameters_[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
+	rootParameters_[4].Descriptor.ShaderRegister = 1;
+
 	CraeteDescriptorTable();
 
 	rootParameters_[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;

--- a/HumimotoEngine/Manager/PipelineManager.h
+++ b/HumimotoEngine/Manager/PipelineManager.h
@@ -97,7 +97,7 @@ private:
 
 	D3D12_VIEWPORT viewport_;
 	D3D12_RECT scissorRect_;
-	D3D12_ROOT_PARAMETER rootParameters_[4];
+	D3D12_ROOT_PARAMETER rootParameters_[5];
 	D3D12_DESCRIPTOR_RANGE descriptorRange_[1];
 	D3D12_STATIC_SAMPLER_DESC staticSamplers_[1];
 };

--- a/HumimotoEngine/Object3d.VS.hlsl
+++ b/HumimotoEngine/Object3d.VS.hlsl
@@ -1,10 +1,16 @@
 #include "Object3d.hlsli"
 
 struct TransformationMatrix {
-    float32_t4x4 WVP;
-    float32_t4x4 World;
+    float32_t4x4 matWorld;
+};
+struct ViewProjectionMatrix {
+    float32_t4x4 view;
+    float32_t4x4 projection;
+    float32_t3 cameraPos;
 };
 ConstantBuffer<TransformationMatrix> gTransformationMatrix : register(b0);
+ConstantBuffer<ViewProjectionMatrix> gViewProjectionMatrix : register(b1);
+
 struct VertexShaderInput {
     float32_t4 position : POSITION0;
     float32_t2 texcoord : TEXCOORD0;
@@ -13,8 +19,9 @@ struct VertexShaderInput {
 
 VertexShaderOutput main(VertexShaderInput input) {
     VertexShaderOutput output;
-    output.position = mul(input.position, gTransformationMatrix.WVP);
+    float32_t4x4 WorldViewProjectionMatrix = mul(gViewProjectionMatrix.view, gViewProjectionMatrix.projection);
+    output.position = mul(input.position, mul(gTransformationMatrix.matWorld, WorldViewProjectionMatrix));
     output.texcoord = input.texcoord;
-    output.normal = normalize(mul(input.normal,(float32_t3x3)gTransformationMatrix.World));
+    output.normal = normalize(mul(input.normal, (float32_t3x3)WorldViewProjectionMatrix));
     return output;
 }

--- a/HumimotoEngine/base/DirectXCommon.cpp
+++ b/HumimotoEngine/base/DirectXCommon.cpp
@@ -154,6 +154,26 @@ void DirectXCommon::CreateSwapChain(HWND hwnd) {
 	assert(SUCCEEDED(hr));
 }
 
+Microsoft::WRL::ComPtr<ID3D12Resource> DirectXCommon::CreateBufferResource(size_t sizeInBytes)
+{
+	Microsoft::WRL::ComPtr<ID3D12Resource> Resource = nullptr;
+	D3D12_HEAP_PROPERTIES uploadHeapProperties{};
+	uploadHeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
+	D3D12_RESOURCE_DESC ResourceDesc{};
+	ResourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+	ResourceDesc.Width = sizeInBytes;
+	ResourceDesc.Height = 1;
+	ResourceDesc.DepthOrArraySize = 1;
+	ResourceDesc.MipLevels = 1;
+	ResourceDesc.SampleDesc.Count = 1;
+	ResourceDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+	HRESULT hr{};
+	//頂点リソースを作る
+	hr = device_.Get()->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE, &ResourceDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(&Resource));
+	assert(SUCCEEDED(hr));
+	return Resource;
+}
+
 Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> DirectXCommon::CreateDescriptorHeap(const Microsoft::WRL::ComPtr<ID3D12Device>& device, D3D12_DESCRIPTOR_HEAP_TYPE heapType, UINT numDescriptors, bool shaderVisible) {
 	HRESULT hr;
 	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> descriptorHeap;

--- a/HumimotoEngine/base/DirectXCommon.h
+++ b/HumimotoEngine/base/DirectXCommon.h
@@ -44,6 +44,9 @@ public:
 	// SwapChainの生成
 	void CreateSwapChain(HWND hwnd);
 
+
+	Microsoft::WRL::ComPtr<ID3D12Resource> CreateBufferResource(size_t sizeInBytes);
+
 	// DescriptorHeapの生成
 	Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> CreateDescriptorHeap(const Microsoft::WRL::ComPtr<ID3D12Device>& device, D3D12_DESCRIPTOR_HEAP_TYPE heapType, UINT numDescriptors, bool shaderVisible);
 

--- a/HumimotoEngine/base/ViewProjection.cpp
+++ b/HumimotoEngine/base/ViewProjection.cpp
@@ -1,0 +1,36 @@
+#include "ViewProjection.h"
+
+void ViewProjection::Initialize() {
+	CreateConstBuffer();
+	Map();
+	UpdateMatrix();
+	TransferMatrix();
+}
+
+void ViewProjection::CreateConstBuffer() {
+	constBuff_ = DirectXCommon::GetInstance()->CreateBufferResource(sizeof(ConstBufferDataViewProjection));
+}
+
+void ViewProjection::Map() {
+	constBuff_.Get()->Map(0, nullptr, reinterpret_cast<void**>(&constMap));
+}
+
+void ViewProjection::UpdateMatrix() {
+	UpdateViewMatrix();
+	UpdateProjectionMatrix();
+	TransferMatrix();
+}
+
+void ViewProjection::TransferMatrix() {
+	constMap->view = matView;
+	constMap->projection = matProjection;
+}
+
+void ViewProjection::UpdateViewMatrix() {
+	Matrix4x4 cameraMatrix = MakeAffineMatrix({ 1.0f,1.0f,1.0f }, rotation_, translation_);
+	matView = Inverse(cameraMatrix);
+}
+
+void ViewProjection::UpdateProjectionMatrix() {
+	matProjection = MakePerspectiveFovMatrix(fovAngleY, aspectRatio, nearZ, farZ);
+}

--- a/HumimotoEngine/base/ViewProjection.h
+++ b/HumimotoEngine/base/ViewProjection.h
@@ -1,0 +1,72 @@
+#pragma once
+#include "DirectXCommon.h"
+#include "../math/Matrix4x4.h"
+#include <d3d12.h>
+#include <wrl.h>
+
+// 定数バッファ用データ構造体
+struct ConstBufferDataViewProjection {
+	Matrix4x4 view;       // ワールド → ビュー変換行列
+	Matrix4x4 projection; // ビュー → プロジェクション変換行列
+	Vector3 cameraPos;    // カメラ座標（ワールド座標）
+};
+
+struct ViewProjection{
+	// 定数バッファ
+	Microsoft::WRL::ComPtr<ID3D12Resource> constBuff_;
+	// マッピング済みアドレス
+	ConstBufferDataViewProjection* constMap = nullptr;
+
+#pragma region ビュー行列の設定
+	// X,Y,Z軸回りのローカル回転角
+	Vector3 rotation_ = { 0, 0, 0 };
+	// ローカル座標
+	Vector3 translation_ = { 0, 0, -50 };
+#pragma endregion
+
+#pragma region 射影行列の設定
+	// 垂直方向視野角
+	float fovAngleY = 45.0f * 3.141592654f / 180.0f;
+	// ビューポートのアスペクト比
+	float aspectRatio = (float)16 / 9;
+	// 深度限界（手前側）
+	float nearZ = 0.1f;
+	// 深度限界（奥側）
+	float farZ = 1000.0f;
+#pragma endregion
+
+	// ビュー行列
+	Matrix4x4 matView;
+	// 射影行列
+	Matrix4x4 matProjection;
+
+	/// <summary>
+	/// 初期化
+	/// </summary>
+	void Initialize();
+	/// <summary>
+	/// 定数バッファ生成
+	/// </summary>
+	void CreateConstBuffer();
+	/// <summary>
+	/// マッピングする
+	/// </summary>
+	void Map();
+	/// <summary>
+	/// 行列を更新する
+	/// </summary>
+	void UpdateMatrix();
+	/// <summary>
+	/// 行列を転送する
+	/// </summary>
+	void TransferMatrix();
+	/// <summary>
+	/// ビュー行列を更新する
+	/// </summary>
+	void UpdateViewMatrix();
+	/// <summary>
+	/// 射影行列を更新する
+	/// </summary>
+	void UpdateProjectionMatrix();
+};
+

--- a/HumimotoEngine/base/WorldTransform.cpp
+++ b/HumimotoEngine/base/WorldTransform.cpp
@@ -1,0 +1,31 @@
+﻿#include "WorldTransform.h"
+
+void WorldTransform::Initialize() {
+	matWorld_ = MakeIdentity4x4();
+	CreateConstBuffer();
+	Map();
+	TransferMatrix();
+}
+
+void WorldTransform::CreateConstBuffer() {
+	constBuff_ = DirectXCommon::GetInstance()->CreateBufferResource(sizeof(ConstBufferDataWorldTransform));
+}
+
+void WorldTransform::Map() {
+	constBuff_.Get()->Map(0, nullptr, reinterpret_cast<void**>(&constMap));
+}
+
+void WorldTransform::TransferMatrix() {
+	constMap->matWorld = matWorld_;
+}
+
+void WorldTransform::UpdateMatrix() {
+	matWorld_ = MakeAffineMatrix(scale_, rotation_, translation_);
+
+	// 親子関係の計算
+	if (parent_) {
+		matWorld_ = Multiply(matWorld_, parent_->matWorld_);
+	}
+
+	TransferMatrix();
+}

--- a/HumimotoEngine/base/WorldTransform.h
+++ b/HumimotoEngine/base/WorldTransform.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "../math/Matrix4x4.h"
+#include "../math/Vector3.h"
+#include "DirectXCommon.h"
+#include <d3d12.h>
+#include <wrl.h>
+
+// 定数バッファ用データ構造体
+struct ConstBufferDataWorldTransform {
+	Matrix4x4 matWorld; // ローカル → ワールド変換行列
+};
+
+/// <summary>
+/// ワールド変換データ
+/// </summary>
+struct WorldTransform {
+	// 定数バッファ
+	Microsoft::WRL::ComPtr<ID3D12Resource> constBuff_;
+	// マッピング済みアドレス
+	ConstBufferDataWorldTransform* constMap = nullptr;
+	// ローカルスケール
+	Vector3 scale_ = { 1, 1, 1 };
+	// X,Y,Z軸回りのローカル回転角
+	Vector3 rotation_ = { 0, 0, 0 };
+	// ローカル座標
+	Vector3 translation_ = { 0, 0, 0 };
+	// ローカル → ワールド変換行列
+	Matrix4x4 matWorld_;
+	// 親となるワールド変換へのポインタ
+	const WorldTransform* parent_ = nullptr;
+
+	/// <summary>
+	/// 初期化
+	/// </summary>
+	void Initialize();
+	/// <summary>
+	/// 定数バッファ生成
+	/// </summary>
+	void CreateConstBuffer();
+	/// <summary>
+	/// マッピングする
+	/// </summary>
+	void Map();
+	/// <summary>
+	/// 行列を転送する
+	/// </summary>
+	void TransferMatrix();
+
+	void UpdateMatrix();
+};

--- a/HumimotoEngine/components/camera/Camera.cpp
+++ b/HumimotoEngine/components/camera/Camera.cpp
@@ -33,7 +33,7 @@ void Camera::SettingCamera() {
 }
 
 void Camera::DrawDebugParameter() {
-	ImGui::Text("Camera");
-	ImGui::SliderFloat3("Camera.Translate", &cameraTransform_.translate.x, -10, 10);
-	ImGui::DragFloat3("Camera.Rotate", &cameraTransform_.rotate.x,0.01f ,-6.28f, 6.28f);
+	//ImGui::Text("Camera");
+	//ImGui::SliderFloat3("Camera.Translate", &cameraTransform_.translate.x, -10, 10);
+	//ImGui::DragFloat3("Camera.Rotate", &cameraTransform_.rotate.x,0.01f ,-6.28f, 6.28f);
 }

--- a/HumimotoEngine/imgui.ini
+++ b/HumimotoEngine/imgui.ini
@@ -9,12 +9,22 @@ Size=271,66
 Collapsed=0
 
 [Window][CommonSettings]
-Pos=59,128
+Pos=26,347
 Size=248,173
 Collapsed=0
 
 [Window][father]
 Pos=60,60
 Size=378,113
+Collapsed=0
+
+[Window][ ]
+Pos=216,114
+Size=441,212
+Collapsed=0
+
+[Window][Blocks Parameter]
+Pos=398,94
+Size=187,277
 Collapsed=0
 

--- a/HumimotoEngine/object/Cube.cpp
+++ b/HumimotoEngine/object/Cube.cpp
@@ -1,0 +1,276 @@
+#include "Cube.h"
+#include <cassert>
+#include "../Manager/ImGuiManager.h"
+
+Cube::Cube() {
+}
+
+Cube::~Cube() {
+
+}
+
+void Cube::Initialize() {
+	CreateVertexResource();
+
+	CreateMaterialResource();
+
+	CreateVertexBufferView();
+
+	// 書き込むためのアドレスを取得
+	vertexResource_.Get()->Map(0, nullptr, reinterpret_cast<void**>(&vertexData_));
+
+	uvTransform_ = {
+	{1.0f,1.0f,1.0f},
+	{0.0f,0.0f,0.0f},
+	{0.0f,0.0f,0.0f}
+	};
+
+#pragma region 正面
+
+	// 左下
+	vertexData_[0].position = { -0.5f, -0.5f, -0.5f,1.0f };
+	vertexData_[0].texcoord = { 0.0f,1.0f };
+	// 左上:
+	vertexData_[1].position = { -0.5f, 0.5f, -0.5f ,1.0f };
+	vertexData_[1].texcoord = { 0.0f,0.0f };
+	// 右下
+	vertexData_[2].position = { 0.5f, -0.5f, -0.5f,1.0f };
+	vertexData_[2].texcoord = { 1.0f,1.0f };
+
+	// 左上
+	vertexData_[3].position = { -0.5f, 0.5f, -0.5f ,1.0f };
+	vertexData_[3].texcoord = { 0.0f,0.0f };
+	// 右上:
+	vertexData_[4].position = { 0.5f, 0.5f, -0.5f ,1.0f };
+	vertexData_[4].texcoord = { 1.0f,0.0f };
+	// 右下
+	vertexData_[5].position = { 0.5f, -0.5f, -0.5f ,1.0f };
+	vertexData_[5].texcoord = { 1.0f,1.0f };
+
+#pragma endregion
+
+#pragma region 左面
+
+	// 左下
+	vertexData_[6].position = { -0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[6].texcoord = { 0.0f,1.0f };
+	// 左上:
+	vertexData_[7].position = { -0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[7].texcoord = { 0.0f,0.0f };
+	// 右下
+	vertexData_[8].position = { -0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[8].texcoord = { 1.0f,1.0f };
+
+	// 左上
+	vertexData_[9].position = { -0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[9].texcoord = { 0.0f,0.0f };
+	// 右上:
+	vertexData_[10].position = { -0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[10].texcoord = { 1.0f,0.0f };
+	// 右下
+	vertexData_[11].position = { -0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[11].texcoord = { 1.0f,1.0f };
+
+#pragma endregion
+
+#pragma region 背面
+
+	// 左下
+	vertexData_[12].position = { 0.5f, -0.5f, 0.5f ,1.0f };
+	vertexData_[12].texcoord = { 0.0f,1.0f };
+	// 左上:
+	vertexData_[13].position = { 0.5f, 0.5f, 0.5f ,1.0f };
+	vertexData_[13].texcoord = { 0.0f,0.0f };
+	// 右下
+	vertexData_[14].position = { -0.5f, -0.5f, 0.5f ,1.0f };
+	vertexData_[14].texcoord = { 1.0f,1.0f };
+
+	// 左上
+	vertexData_[15].position = { 0.5f, 0.5f, 0.5f ,1.0f };
+	vertexData_[15].texcoord = { 0.0f,0.0f };
+	// 右上:
+	vertexData_[16].position = { -0.5f, 0.5f, 0.5f ,1.0f };
+	vertexData_[16].texcoord = { 1.0f,0.0f };
+	// 右下
+	vertexData_[17].position = { -0.5f, -0.5f, 0.5f ,1.0f };
+	vertexData_[17].texcoord = { 1.0f,1.0f };
+
+#pragma endregion
+
+#pragma region 上面
+
+	// 左下
+	vertexData_[18].position = { 0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[18].texcoord = { 0.0f,0.0f };
+	// 左上:
+	vertexData_[19].position = { 0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[19].texcoord = { 0.0f,1.0f };
+	// 右下
+	vertexData_[20].position = { -0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[20].texcoord = { 1.0f,0.0f };
+
+	// 左上
+	vertexData_[21].position = { 0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[21].texcoord = { 0.0f,1.0f };
+	// 右上:
+	vertexData_[22].position = { -0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[22].texcoord = { 1.0f,1.0f };
+	// 右下
+	vertexData_[23].position = { -0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[23].texcoord = { 1.0f,0.0f };
+
+#pragma endregion
+
+#pragma region 右面
+
+	// 左下
+	vertexData_[24].position = { 0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[24].texcoord = { 0.0f,1.0f };
+	// 左上:
+	vertexData_[25].position = { 0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[25].texcoord = { 0.0f,0.0f };
+	// 右下
+	vertexData_[26].position = { 0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[26].texcoord = { 1.0f,1.0f };
+
+	// 左上
+	vertexData_[27].position = { 0.5f, 0.5f, -0.5f, 1.0f };
+	vertexData_[27].texcoord = { 0.0f,0.0f };
+	// 右上:
+	vertexData_[28].position = { 0.5f, 0.5f, 0.5f, 1.0f };
+	vertexData_[28].texcoord = { 1.0f,0.0f };
+	// 右下
+	vertexData_[29].position = { 0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[29].texcoord = { 1.0f,1.0f };
+
+#pragma endregion
+
+#pragma region 底面
+
+	// 左下
+	vertexData_[30].position = { 0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[30].texcoord = { 0.0f,1.0f };
+	// 左上:
+	vertexData_[31].position = { 0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[31].texcoord = { 0.0f,0.0f };
+	// 右下
+	vertexData_[32].position = { -0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[32].texcoord = { 1.0f,1.0f };
+
+	// 左上
+	vertexData_[33].position = { 0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[33].texcoord = { 0.0f,0.0f };
+	// 右上:
+	vertexData_[34].position = { -0.5f, -0.5f, 0.5f, 1.0f };
+	vertexData_[34].texcoord = { 1.0f,0.0f };
+	// 右下
+	vertexData_[35].position = { -0.5f, -0.5f, -0.5f, 1.0f };
+	vertexData_[35].texcoord = { 1.0f,1.0f };
+
+#pragma endregion
+
+	// 法線の向き
+	for (int i = 0; i < 36; i++) {
+		vertexData_[i].normal = { vertexData_[i].position.x,vertexData_[i].position.y,vertexData_[i].position.z };
+	}
+
+	// 色
+	materialData_->color = { 1.0f,1.0f,1.0f,1.0f };
+
+	materialData_->uvTransform = MakeIdentity4x4();
+	
+	materialData_->enableLighting = false;
+}
+
+void Cube::Draw(const WorldTransform& worldTransform, const ViewProjection& viewProjection, int textureNum) {
+	//uvTransformMatrix_ = MakeScaleMatrix(uvTransform_.scale);
+	//uvTransformMatrix_ = Multiply(uvTransformMatrix_, MakeRotateZMatrix(uvTransform_.rotate.z));
+	//uvTransformMatrix_ = Multiply(uvTransformMatrix_, MakeTranslateMatrix(uvTransform_.translate));
+	//materialData_->uvTransform = uvTransformMatrix_;
+
+	// コマンドを積む
+	DirectXCommon::GetInstance()->GetCommandList()->IASetVertexBuffers(0, 1, &vertexBufferView_); // VBVを設定
+	DirectXCommon::GetInstance()->GetCommandList()->SetGraphicsRootConstantBufferView(1, worldTransform.constBuff_->GetGPUVirtualAddress());
+
+	DirectXCommon::GetInstance()->GetCommandList()->SetGraphicsRootConstantBufferView(4, viewProjection.constBuff_->GetGPUVirtualAddress());
+	// 形状を設定。PSOに設定しているものとはまた別。同じものを設定すると考えておけば良い
+	DirectXCommon::GetInstance()->GetCommandList()->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	// マテリアルCBufferの場所を設定
+	DirectXCommon::GetInstance()->GetCommandList()->SetGraphicsRootConstantBufferView(0, materialResource_.Get()->GetGPUVirtualAddress());
+
+	// DescriptorTableの設定
+	DirectXCommon::GetInstance()->GetCommandList()->SetGraphicsRootDescriptorTable(2, TextureManager::GetInstance()->GetTextureSrvHandleGPU()[textureNum]);
+
+	DirectXCommon::GetInstance()->GetCommandList()->SetGraphicsRootConstantBufferView(3, Light::GetInstance()->GetDirectionalLightResource()->GetGPUVirtualAddress());
+
+	// 描画(DrawCall/ドローコール)。3頂点で1つのインスタンス。インスタンスについては今後
+	DirectXCommon::GetInstance()->GetCommandList()->DrawInstanced(36, 1, 0, 0);
+}
+
+void Cube::ApplyGlobalVariables() {
+
+}
+
+void Cube::ImGuiAdjustParameter() {
+	//ImGui::SliderFloat3("Translation", &transform_.translate.x, -5.0f, 5.0f);
+	ImGui::SliderFloat3("Scale", &transform_.scale.x, -5.0f, 5.0f);
+	ImGui::SliderFloat3("Rotate", &transform_.rotate.x, -6.28f, 6.28f);
+	ImGui::ColorEdit3("color", &materialData_->color.x);
+}
+
+const Microsoft::WRL::ComPtr<ID3D12Resource> Cube::CreateBufferResource(size_t sizeInBytes) {
+	HRESULT hr;
+	// 頂点リソース用のヒープの設定
+	D3D12_HEAP_PROPERTIES uploadHeapProperties{};
+	uploadHeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD; // UploadHeapを使う
+	// 頂点リソースの設定
+	D3D12_RESOURCE_DESC vertexResourceDesc{};
+	// バッファソース。テクスチャの場合はまた別の設定をする
+	vertexResourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+	vertexResourceDesc.Width = sizeInBytes; // リソースのサイズ。今回はVector4を3頂点分
+	// バッファの場合はこれからは1にする決まり
+	vertexResourceDesc.Height = 1;
+	vertexResourceDesc.DepthOrArraySize = 1;
+	vertexResourceDesc.MipLevels = 1;
+	vertexResourceDesc.SampleDesc.Count = 1;
+	// バッファの場合はこれにする決まり
+	vertexResourceDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+
+	Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource;
+	// 実際に頂点リソースを作る
+	hr = DirectXCommon::GetInstance()->GetDevice()->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE,
+		&vertexResourceDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr, IID_PPV_ARGS(vertexResource.GetAddressOf()));
+	assert(SUCCEEDED(hr));
+
+	return vertexResource;
+}
+
+void Cube::CreateVertexResource() {
+	vertexResource_ = CreateBufferResource(sizeof(VertexData) * 36).Get();
+}
+
+void Cube::CreateVertexBufferView() {
+	// リソースの先頭のアドレスから使う
+	vertexBufferView_.BufferLocation = vertexResource_.Get()->GetGPUVirtualAddress();
+	// 使用するリソースのサイズは頂点3つ分のサイズ
+	vertexBufferView_.SizeInBytes = sizeof(VertexData) * 36;
+	// 1頂点当たりのサイズ
+	vertexBufferView_.StrideInBytes = sizeof(VertexData);
+}
+
+void Cube::CreateMaterialResource() {
+	materialResource_ = CreateBufferResource(sizeof(Material)).Get();
+	// マテリアルにデータを書き込む
+	materialData_ = nullptr;
+	// 書き込むためのアドレスを取得
+	materialResource_.Get()->Map(0, nullptr, reinterpret_cast<void**>(&materialData_));
+}
+
+void Cube::CreateWvpResource() {
+	// 1つ分のサイズを用意する
+	wvpResource_ = CreateBufferResource(sizeof(TransformationMatrix)).Get();
+	// 書き込むためのアドレスを取得
+	wvpResource_.Get()->Map(0, nullptr, reinterpret_cast<void**>(&wvpData_));
+	// 単位行列を書き込んでおく
+	wvpData_->WVP = MakeIdentity4x4();
+}

--- a/HumimotoEngine/object/Cube.h
+++ b/HumimotoEngine/object/Cube.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "../base/DirectXCommon.h"
+#include "../math/Vector4.h"
+#include "../math/Matrix4x4.h"
+#include "../Transform.h"
+#include "../VertexData.h"
+#include "../Material.h"
+#include <wrl.h>
+#include "../base/WorldTransform.h"
+#include "../base/ViewProjection.h"
+
+class Cube
+{
+public:
+	/// 
+	/// Default Method
+	/// 
+	Cube();
+
+	~Cube();
+	// 初期化
+	void Initialize();
+
+	// 三角形描画
+	void Draw(const WorldTransform& worldTransform, const ViewProjection& viewProjection, int textureNum);
+
+	// Getter
+	const Microsoft::WRL::ComPtr<ID3D12Resource> GetMaterialResource() { return materialResource_.Get(); }
+
+	// Setter
+	void SetTextureSrvHandleGPU(D3D12_GPU_DESCRIPTOR_HANDLE textureSrvHandleGPU) { textureSrvHandleGPU_ = textureSrvHandleGPU; }
+
+	// Resource生成
+	const Microsoft::WRL::ComPtr<ID3D12Resource> CreateBufferResource(size_t sizeInBytes);
+
+	// VertexResourceの生成
+	void CreateVertexResource();
+
+	// VertexBufferViewの生成
+	void CreateVertexBufferView();
+
+	// MaterialResourceの生成
+	void CreateMaterialResource();
+
+	// TransformationMatrix用のResourceを生成
+	void CreateWvpResource();
+
+	/// 
+	/// User Method
+	/// 
+	void ApplyGlobalVariables();
+
+	void ImGuiAdjustParameter();
+
+public:
+	D3D12_GPU_DESCRIPTOR_HANDLE textureSrvHandleGPU_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> vertexResource_;
+	D3D12_VERTEX_BUFFER_VIEW vertexBufferView_;
+	VertexData* vertexData_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> materialResource_;
+	Material* materialData_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> wvpResource_;
+	TransformationMatrix* wvpData_;
+	Transform transform_;
+	Transform uvTransform_;
+	Matrix4x4 uvTransformMatrix_;
+};
+

--- a/HumimotoEngine/object/Triangle.cpp
+++ b/HumimotoEngine/object/Triangle.cpp
@@ -56,24 +56,9 @@ void Triangle::Initialize() {
 	materialData_->uvTransform = MakeIdentity4x4();
 
 	materialData_->enableLighting = false;
-
-	GlobalVariables* globalVariables = GlobalVariables::GetInstance();
-	const char* groupName = "Triangle";
-	GlobalVariables::GetInstance()->CreateGroup(groupName);
-	globalVariables->AddItem(groupName, "translation", transform_.translate);
-	globalVariables->AddItem(groupName, "scale", transform_.scale);
-	globalVariables->AddItem(groupName, "rotate", transform_.rotate);
-	globalVariables->AddItem(groupName, "Color", materialData_->color);
 }
 
 void Triangle::Draw() {
-	ApplyGlobalVariables();
-	GlobalVariables* globalVariables = GlobalVariables::GetInstance();
-	// ボタンを押したらsave
-	if (globalVariables->GetInstance()->GetIsSave()) {
-		globalVariables->SaveFile("Triangle");
-	}
-
 	uvTransformMatrix_ = MakeScaleMatrix(uvTransform_.scale);
 	uvTransformMatrix_ = Multiply(uvTransformMatrix_, MakeRotateZMatrix(uvTransform_.rotate.z));
 	uvTransformMatrix_ = Multiply(uvTransformMatrix_, MakeTranslateMatrix(uvTransform_.translate));
@@ -98,19 +83,11 @@ void Triangle::Draw() {
 }
 
 void Triangle::ApplyGlobalVariables() {
-	GlobalVariables* globalVariables = GlobalVariables::GetInstance();
-	const char* groupName = "Triangle";
-	transform_.translate = globalVariables->GetVector3Value(groupName, "translation");
-	transform_.scale = globalVariables->GetVector3Value(groupName, "scale");
-	transform_.rotate = globalVariables->GetVector3Value(groupName, "rotate");
-	materialData_->color = globalVariables->GetVector4Value(groupName, "Color");
+
 }
 
 void Triangle::ImGuiAdjustParameter() {
-	//ImGui::SliderFloat3("Translation", &transform_.translate.x, -5.0f, 5.0f);
-	ImGui::SliderFloat3("Scale", &transform_.scale.x, -5.0f, 5.0f);
-	ImGui::SliderFloat3("Rotate", &transform_.rotate.x, -6.28f, 6.28f);
-	ImGui::ColorEdit3("color", &materialData_->color.x);
+
 }
 
 const Microsoft::WRL::ComPtr<ID3D12Resource> Triangle::CreateBufferResource(size_t sizeInBytes) {

--- a/HumimotoEngine/scene/TitleScene.cpp
+++ b/HumimotoEngine/scene/TitleScene.cpp
@@ -1,28 +1,45 @@
-#include "TitleScene.h"
+﻿#include "TitleScene.h"
 #include "../Manager/GameManager.h"
 
 void TitleScene::Initialize() {
-	sprite_ = new Sprite();
-	sprite_->Initialize();
-	sphere_ = new Sphere();
-	sphere_->Initialize();
 	textureNum_ = UVCHEKER;
 	input_ = Input::GetInstance();
 	block_ = new Block();
 	block_->Initialize();
-	pos_ = { 0,0,30 };
+	cube_ = new Cube();
+	cube_->Initialize();
+
+	worldTransform_.Initialize();
+	cubeWorldTransform_.Initialize();
+	viewProjection_.Initialize();
+
+	cubeWorldTransform_.translation_ = { 4,0,0 };
 }
 
 void TitleScene::Update() {
+	worldTransform_.UpdateMatrix();
+	cubeWorldTransform_.UpdateMatrix();
+	viewProjection_.UpdateMatrix();
 
+	ImGui::Begin("Blocks Parameter");
+	ImGui::DragFloat3("objBlock:translation", &worldTransform_.translation_.x, 0.1f);
+	ImGui::DragFloat3("objBlock:rotation", &worldTransform_.rotation_.x, 0.1f);
+	ImGui::DragFloat3("objBlock:scale", &worldTransform_.scale_.x, 0.1f);
+	ImGui::DragFloat3("meshBlock:translation", &cubeWorldTransform_.translation_.x, 0.1f);
+	ImGui::DragFloat3("meshBlock:rotation", &cubeWorldTransform_.rotation_.x, 0.1f);
+	ImGui::DragFloat3("meshBlock:scale", &cubeWorldTransform_.scale_.x, 0.1f);
+	ImGui::End();
 }
 
 void TitleScene::Draw() {
-	block_->Draw(pos_, {1,1,1},{0,0,0},BLOCK);
+	block_->Draw(worldTransform_,viewProjection_,BLOCK);
+	cube_->Draw(cubeWorldTransform_, viewProjection_, UVCHEKER);
 }
 
 void TitleScene::Finalize() {
-	delete sprite_;
-	delete sphere_;
+	worldTransform_.constBuff_.ReleaseAndGetAddressOf();
+	cubeWorldTransform_.constBuff_.ReleaseAndGetAddressOf();
+	viewProjection_.constBuff_.ReleaseAndGetAddressOf();
 	delete block_;
+	delete cube_;
 }

--- a/HumimotoEngine/scene/TitleScene.h
+++ b/HumimotoEngine/scene/TitleScene.h
@@ -1,11 +1,12 @@
-#pragma once
+﻿#pragma once
 #include "IScene.h"
 #include "../components/Input.h"
-#include "../object/Sprite.h"
-#include "../object/Sphere.h"
+#include "../object/Cube.h"
 
 #include "../../Class/Models/Block.h"
 #include "../../Class/Effect/EffectManager.h"
+#include "../base/WorldTransform.h"
+#include "../base/ViewProjection.h"
 
 class GameManager;
 
@@ -17,12 +18,17 @@ public:
 	void Draw() override;
 	void Finalize()override;
 private:
-	Sprite* sprite_;
-	Sphere* sphere_;
 	int textureNum_;
 	Input* input_;
 	Vector3 pos_;
 
 	Block* block_;
+	// 処理の軽いBlock(背面カリング)
+	Cube* cube_;
 	EffectManager effectManager_;
+
+	// worldTransformとviewProjectionの動作チェック用
+	WorldTransform worldTransform_;
+	WorldTransform cubeWorldTransform_;
+	ViewProjection viewProjection_;
 };


### PR DESCRIPTION
・WorldTransformとViewProjectionの追加
・BlockクラスのDraw関数の引数、積むコマンドを増やした。
・ルートシグネチャとシェーダの処理内容の変更。使い方は変わらない。
・背面カリングされた立方体を描画できるcubeクラスを追加

注意点
・worldTransformとviewProjectionを使用するときは必ず解放処理を呼び出すこと。 例) worldTransform_.constBuff_.ReleaseAndGetAddressOf(); viewProjection_.constBuff_.ReleaseAndGetAddressOf();

・objectファイル内に入ってるshere,triangleなどは使わないように。Draw関数内で積むべきコマンドを呼び出していないのでエラーが起きます。もし使いたいなら連絡ください